### PR TITLE
[PAN-1742] fix revert message retrieval

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,8 @@ repos:
     hooks:
       - id: mypy
         files: ^pantos/common
-        additional_dependencies: ['types-requests', 'types-PyYAML']
+        args: ['--namespace-packages', '--explicit-package-bases' ]
+        additional_dependencies: ['types-requests', 'types-PyYAML', 'web3[tester]']
         stages: [ commit ]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Getting the revert message of a transaction fails.

## QA Instructions

It the service queries the status of a reverted transaction, the revert reason should be properly logged. If fetching it fails, the field should just be an "unknown" string.